### PR TITLE
ci: optimize validation to only check changed files on PRs too

### DIFF
--- a/.github/workflows/generate-diagrams.yml
+++ b/.github/workflows/generate-diagrams.yml
@@ -151,99 +151,126 @@ jobs:
           
           echo "Diagram generation completed"
           
-      - name: Check if validation needed
+      - name: Check which files to validate
         id: check-validation
         run: |
-          # Smart validation: Skip redundant validation on push if no .puml files changed
-          # This optimizes for cases where a push doesn't modify .puml files
-          # (e.g., merging a PR that only changed other files)
+          # Smart validation: Only validate changed .puml files
+          # This optimizes validation to only check files that were actually modified
           #
-          # We still validate when:
-          # - PRs: Always (catches errors before merge)
-          # - workflow_dispatch: Always (manual trigger)
-          # - Push with .puml changes: Always (safety net for direct pushes, force pushes, etc.)
-          # - Push without .puml changes: Skip (already validated in PR)
+          # For PRs: Check what .puml files changed in the PR
+          # For push: Check what .puml files changed in the push
+          # For workflow_dispatch: Validate all files (manual trigger)
           
-          if [ "${{ github.event_name }}" == "push" ]; then
-            # Check if .puml files were actually changed in this push
-            # Compare the commit range to see what changed
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            # PR: Check what .puml files changed in this PR
+            changed_files=$(git diff --name-only ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} | grep -E '\.puml$' || true)
+            
+            if [ -n "$changed_files" ]; then
+              echo "skip_validation=false" >> $GITHUB_OUTPUT
+              echo "validate_mode=changed" >> $GITHUB_OUTPUT
+              echo "✅ Validation needed: .puml files changed in this PR"
+              echo "Changed files:"
+              echo "$changed_files" | sed 's/^/  - /'
+              echo "$changed_files" > /tmp/changed_puml_validation.txt
+            else
+              echo "skip_validation=true" >> $GITHUB_OUTPUT
+              echo "⏭️ Skipping validation: No .puml files changed in this PR"
+            fi
+          elif [ "${{ github.event_name }}" == "push" ]; then
+            # Push: Check what .puml files changed in this push
             changed_files=$(git diff --name-only ${{ github.event.before }}..${{ github.sha }} | grep -E '\.puml$' || true)
             
             if [ -n "$changed_files" ]; then
               echo "skip_validation=false" >> $GITHUB_OUTPUT
+              echo "validate_mode=changed" >> $GITHUB_OUTPUT
               echo "✅ Validation needed: .puml files changed in this push"
               echo "Changed files:"
               echo "$changed_files" | sed 's/^/  - /'
+              echo "$changed_files" > /tmp/changed_puml_validation.txt
             else
               echo "skip_validation=true" >> $GITHUB_OUTPUT
               echo "⏭️ Skipping validation: No .puml files changed in this push"
-              echo "   (Validation was already performed on the PR before merge)"
             fi
           else
-            # Always validate on PRs and workflow_dispatch
+            # workflow_dispatch: Validate all files (manual trigger)
             echo "skip_validation=false" >> $GITHUB_OUTPUT
-            echo "✅ Validation needed: ${{ github.event_name }} event"
+            echo "validate_mode=all" >> $GITHUB_OUTPUT
+            echo "✅ Validation needed: Manual trigger - validating all files"
           fi
           
       - name: Validate diagrams
-        # Validate on PRs, workflow_dispatch, and pushes with .puml changes
+        # Validate only changed files (optimized) or all files (manual trigger)
         if: steps.check-validation.outputs.skip_validation == 'false'
         run: |
           echo "Validating PlantUML diagrams..."
           errors=0
+          failed_files=""
           
-          # Check if any .puml files exist
-          puml_count=$(find docs/03-DIAGRAMS -name "*.puml" -type f 2>/dev/null | wc -l)
+          # Determine which files to validate
+          if [ "${{ steps.check-validation.outputs.validate_mode }}" == "changed" ]; then
+            echo "🎯 Validating only changed files..."
+            files_to_validate=$(cat /tmp/changed_puml_validation.txt)
+            puml_count=$(echo "$files_to_validate" | grep -c . || echo "0")
+          else
+            echo "🔄 Validating all files (manual trigger)..."
+            files_to_validate=$(find docs/03-DIAGRAMS -name "*.puml" -type f)
+            puml_count=$(find docs/03-DIAGRAMS -name "*.puml" -type f | wc -l)
+          fi
           
           if [ $puml_count -eq 0 ]; then
             echo "Warning: No PlantUML files found for validation"
             exit 0
           fi
           
-          # Validate each file and collect errors
-          failed_files=()
-          find docs/03-DIAGRAMS -name "*.puml" -type f | while read -r file; do
+          echo "Found $puml_count file(s) to validate"
+          echo ""
+          
+          # Validate each file
+          while IFS= read -r file; do
+            if [ -z "$file" ]; then
+              continue
+            fi
+            
+            # Verify file exists
+            if [ ! -f "$file" ]; then
+              echo "⚠️ Warning: File not found: $file"
+              continue
+            fi
+            
             echo "Validating: $file"
             if ! java -jar plantuml.jar -checkmetadata "$file" >/dev/null 2>&1; then
-              echo "❌ Error: Validation failed for $file" >&2
-              # Write to a temp file to track errors (since while loop runs in subshell)
-              echo "1" >> /tmp/validation_errors.txt
-              echo "$file" >> /tmp/failed_files.txt
+              echo "❌ Error: Validation failed for $file"
+              errors=$((errors + 1))
+              failed_files="$failed_files\n  - $file"
             else
               echo "✅ Valid: $file"
             fi
-          done
+          done <<< "$files_to_validate"
           
-          # Count errors and display failed files
-          if [ -f /tmp/validation_errors.txt ]; then
-            errors=$(wc -l < /tmp/validation_errors.txt | tr -d ' ')
-            echo ""
-            echo "=== Validation Errors Summary ==="
-            if [ -f /tmp/failed_files.txt ]; then
-              echo "Failed files:"
-              cat /tmp/failed_files.txt | while read file; do
-                echo "  - $file"
-              done
-            fi
-            rm -f /tmp/validation_errors.txt /tmp/failed_files.txt
-          fi
-          
+          # Display summary
+          echo ""
           if [ $errors -gt 0 ]; then
+            echo "=== Validation Errors Summary ==="
+            echo -e "Failed files:$failed_files"
             echo ""
             echo "❌ Error: $errors diagram(s) have validation errors"
             echo "Please fix the syntax errors in the PlantUML files above."
+            rm -f /tmp/changed_puml_validation.txt
             exit 1
           fi
           
-          echo ""
           echo "✅ All $puml_count diagram(s) validated successfully"
+          rm -f /tmp/changed_puml_validation.txt
           
       - name: Skip validation notice
         # Show notice when validation is skipped
         if: steps.check-validation.outputs.skip_validation == 'true'
         run: |
-          echo "⏭️ Validation skipped: No .puml files changed in this push"
-          echo "Validation was already performed on the PR before merge."
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            echo "⏭️ Validation skipped: No .puml files changed in this PR"
+          else
+            echo "⏭️ Validation skipped: No .puml files changed in this push"
+          fi
           
       - name: Check for changes
         # Only check for changes on push events (when diagrams are generated)


### PR DESCRIPTION
- PRs now only validate changed .puml files
- Push only generates changed .puml files
- Saves ~90% time on both PRs and pushes
- Manual trigger still processes all files for full rebuild