### PR TITLE
feature/101/TASK-1-1-7: Configure .gitignore for all services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,18 @@ temp/
 # Backup files
 *.bak
 *.backup
+
+# Docker
+docker-compose.override.yml
+.docker/
+
+# Database data directories
+database/data/
+database/redis/
+*.db
+*.sqlite
+*.sqlite3
+
+# Container volumes
+volumes/
+data/


### PR DESCRIPTION
All .gitignore files are now configured:
Root .gitignore - Common patterns + Docker patterns
Java Spring Boot services (auth, profile, leaderboard) - Maven/Spring patterns
Node.js services (game-engine, matchmaking-service) - Node.js patterns
Angular frontend-service - Angular patterns
Docker patterns - Added to root .gitignore