### PR TITLE
Feature/100 task 1 1 8 create service specific readme files root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # 🎮 Battle Arena
 
+[![Status](https://img.shields.io/badge/status-active_development-yellow)]()
+[![License](https://img.shields.io/badge/license-MIT-blue)]()
+[![Java](https://img.shields.io/badge/java-17-orange)]()
+[![Node](https://img.shields.io/badge/node-18+-green)]()
+[![Angular](https://img.shields.io/badge/angular-17+-red)]()
+
 > *Where strategy meets nostalgia, and every shot counts.*
 
 **Battle Arena** is a modern multiplayer 2D artillery battle game that brings the classic Pocket Tank experience into the 21st century. Think of it as your favorite retro artillery game, but now you can battle real players from around the world, climb leaderboards, and prove you're the ultimate artillery master.
@@ -98,11 +104,23 @@ Battle Arena follows a **microservices architecture**, which means each part of 
 
 ### Core Services
 
-1. **Auth Service** - Handles user registration, login, Google OAuth, and JWT tokens
-2. **Profile Service** - Manages player profiles, scores, and rank progression
-3. **Leaderboard Service** - Powers those competitive rankings (with smart filtering)
-4. **Matchmaking Service** - Finds you the perfect opponent in seconds
-5. **Game Engine Service** - The heart of the game: physics, turns, scoring
+This project follows a **microservices architecture** with the following services:
+
+| Service | Technology | Port | Description |
+|---------|-----------|------|-------------|
+| **Auth Service** | Spring Boot (Java) | 8081 | User registration, login, Google OAuth, JWT tokens |
+| **Profile Service** | Spring Boot (Java) | 8082 | Player profiles, scores, rank progression |
+| **Leaderboard Service** | Spring Boot (Java) | 8083 | Rankings and leaderboards with filtering |
+| **Matchmaking Service** | Node.js (Express, Socket.io) | 3002 | Hero selection, matchmaking, arena/weapon selection |
+| **Game Engine Service** | Node.js (Express, Socket.io) | 5002 | Game logic, physics, turns, scoring |
+| **Frontend Service** | Angular 17+ | 4200 | User interface and game client |
+
+**Data Stores:**
+- **MongoDB** - Persistent data storage (Users, Profiles, Matches, Leaderboard, Heroes, Weapons, Arenas)
+- **Redis** - Caching and queues (matchmaking queue, game state cache, configuration cache)
+
+**API Gateway:**
+- **Nginx** - Reverse proxy, load balancing, SSL termination
 
 ---
 
@@ -110,11 +128,12 @@ Battle Arena follows a **microservices architecture**, which means each part of 
 
 ### Prerequisites
 
-- **Java 17+** (for Spring Boot services)
-- **Node.js 18+** (for matchmaking and game engine)
-- **Docker & Docker Compose** (for easy local setup)
-- **MongoDB** (or use Docker)
-- **Redis** (or use Docker)
+- **Docker & Docker Compose** - For containerized services and easy local setup
+- **Java 17+** - For Spring Boot services (Auth, Profile, Leaderboard)
+- **Node.js 18+** - For Node.js services (Matchmaking, Game Engine)
+- **Git** - For version control
+- **MongoDB** - Database (or use Docker container)
+- **Redis** - Cache and queues (or use Docker container)
 
 ### Quick Start
 
@@ -131,11 +150,18 @@ Battle Arena follows a **microservices architecture**, which means each part of 
 
 3. **Access the game**
    - Frontend: `http://localhost:4200`
-   - API Gateway: `http://localhost:80`
+   - API Gateway: `http://localhost:80` (routes to backend services)
+   - Auth Service: `http://localhost:8081`
+   - Profile Service: `http://localhost:8082`
+   - Leaderboard Service: `http://localhost:8083`
+   - Matchmaking Service: `http://localhost:3002` (WebSocket)
+   - Game Engine Service: `http://localhost:5002` (WebSocket)
 
 4. **Create an account and start playing!** 🎮
 
-> 💡 **Tip:** Check out my [detailed setup guide](./docs/01-GETTING_STARTED/README.md) for more information.
+> 💡 **Tip:** Check out the [detailed setup guide](./docs/01-GETTING_STARTED/README.md) for more information.
+
+> 🔧 **Environment Setup:** Create `.env` files for each service based on `.env.example` templates (if available).
 
 ---
 
@@ -192,24 +218,74 @@ battle-arena/
 
 ## 📚 Documentation
 
-I've got you covered with comprehensive documentation:
+Comprehensive documentation is available in the `docs/` folder:
 
-- **[Project Description](./docs/00-PROJECT_DEFINITION/PROJECT_DESCRIPTION_PLAIN_ENGLISH.md)** - What I'm building
-- **[Architecture Overview](./docs/02-ARCHITECTURE/HIGH_LEVEL_DESIGN/README.md)** - How everything works
-- **[Getting Started Guide](./docs/01-GETTING_STARTED/README.md)** - Detailed setup instructions
-- **[Development Phases](./docs/05-PROJECT_MANAGEMENT/PROJECT_BREAKDOWN.md)** - My implementation roadmap
+### Architecture & Design
+- **[Architecture Overview](./docs/02-ARCHITECTURE/HIGH_LEVEL_DESIGN/README.md)** - System architecture and component design
+- **[Project Description](./docs/00-PROJECT_DEFINITION/PROJECT_DESCRIPTION.md)** - Complete project specification
+- **[System Architecture](./docs/02-ARCHITECTURE/HIGH_LEVEL_DESIGN/02-SYSTEM_ARCHITECTURE.md)** - Detailed architecture documentation
+- **[Component Design](./docs/02-ARCHITECTURE/HIGH_LEVEL_DESIGN/03-COMPONENT_DESIGN.md)** - Service structure and responsibilities
+- **[Database Design](./docs/02-ARCHITECTURE/HIGH_LEVEL_DESIGN/06-DATABASE_DESIGN.md)** - Database schema and relationships
+
+### Getting Started
+- **[Getting Started Guide](./docs/01-GETTING_STARTED/README.md)** - Detailed setup and installation instructions
+- **[Project Management](./docs/05-PROJECT_MANAGEMENT/PROJECT_BREAKDOWN.md)** - Development phases and roadmap
+
+### Visual Documentation
+- **[Architecture Diagrams](./docs/03-DIAGRAMS/README.md)** - Visual architecture diagrams and flow charts
+- **[ER Diagrams](./docs/03-DIAGRAMS/er-diagrams/)** - Database entity relationships
+- **[Sequence Diagrams](./docs/03-DIAGRAMS/sequence-diagrams/)** - Service interaction flows
+
+For complete documentation index, see [docs/README.md](./docs/README.md)
 
 ---
 
 ## 🎯 Design Principles
 
-I take code quality seriously. Every line of code follows these principles:
+Code quality is a top priority. Every line of code follows these principles:
 
-- **🔄 Reusability** - Write once, use everywhere
-- **✨ Clean Code** - Readable, maintainable, self-documenting
-- **🏗️ Clean Architecture** - Clear separation of concerns
+- **🔄 Reusability** - All components, services, and utilities designed for maximum reusability
+- **✨ Clean Code** - Readable, maintainable, self-documenting code
+- **🏗️ Clean Architecture** - Strict separation of concerns with clear boundaries between layers
 - **🔒 Security First** - Defense in depth, input validation, secure by default
-- **📐 SOLID Principles** - Industry best practices
+- **📐 SOLID Principles** - Industry best practices (DRY, SOLID, design patterns)
+
+## 💻 Development
+
+### Development Workflow
+
+1. **Setup Development Environment**
+   ```bash
+   # Install dependencies for each service
+   cd backend-services/auth-service && ./mvnw clean install
+   cd ../matchmaking-service && npm install
+   # ... repeat for other services
+   ```
+
+2. **Run Services Locally**
+   - Use Docker Compose for full stack: `docker-compose up`
+   - Or run services individually for development
+   - Services communicate via Docker network (use service names) or localhost
+
+3. **Testing**
+   - Unit tests: Run tests for each service independently
+   - Integration tests: Test service interactions
+   - End-to-end tests: Test complete user flows
+
+4. **Code Quality**
+   - Follow SOLID principles
+   - Maintain clean architecture layers
+   - Write reusable components
+   - Document complex logic
+   - Security-first approach
+
+### Testing Instructions
+
+- **Spring Boot Services:** `./mvnw test`
+- **Node.js Services:** `npm test`
+- **Angular Frontend:** `ng test` or `npm test`
+
+See individual service README files for service-specific testing instructions.
 
 ---
 

--- a/backend-services/auth-service/README.md
+++ b/backend-services/auth-service/README.md
@@ -2,23 +2,31 @@
 
 Spring Boot service for user authentication and authorization.
 
+## Description
+
+The Auth Service handles all user authentication and authorization operations for Battle Arena, including local authentication, Google OAuth, and JWT token management.
+
+## Technology Stack
+
+- **Framework:** Spring Boot 3.x
+- **Language:** Java 17
+- **Database:** MongoDB (Users collection)
+- **Authentication:** JWT tokens, Google OAuth 2.0
+- **Password Hashing:** BCrypt
+
 ## Port
-8081
 
-## Tech Stack
-- Spring Boot 3.x
-- Java 17
-- MongoDB
-- JWT tokens
-- BCrypt password hashing
+**8081**
 
-## What It Does
-- User registration
-- User login
+## Responsibilities
+
+- User registration and authentication
+- OAuth authentication (Google OAuth 2.0)
 - JWT token generation and validation
-- Google OAuth login
-- Password hashing
+- Password hashing and security
+- Session management
+- Account linking for OAuth users
 
 ## Status
-🚧 Just set up - ready for implementation
 
+🚧 **Ready for Implementation**

--- a/backend-services/game-engine/README.md
+++ b/backend-services/game-engine/README.md
@@ -1,26 +1,41 @@
 # Game Engine Service
 
-Node.js service that runs the actual game - physics, turns, scoring, everything.
+Node.js service that handles real-time game logic, physics, and turn management for 2D artillery battles.
+
+## Description
+
+The Game Engine Service manages the actual gameplay including turn-based mechanics, physics calculations, movement, scoring, health management, and match result processing.
+
+## Technology Stack
+
+- **Runtime:** Node.js 18+
+- **Framework:** Express
+- **Real-time:** Socket.io (WebSocket)
+- **Physics Engine:** Matter.js
+- **Database:** MongoDB (Matches collection)
+- **Cache:** Redis (Game state cache)
 
 ## Port
-5002
 
-## Tech Stack
-- Node.js
-- Express
-- Socket.io (WebSocket)
-- Matter.js (Physics engine)
-- MongoDB (Matches collection)
-- Redis (Game state cache)
+**5002**
 
-## What It Does
+## Responsibilities
+
 - Game room management
 - Real-time game state synchronization
-- Turn management (15s per turn, 4-5min matches)
-- Physics calculations
-- Scoring system
-- Health management
+- Turn management (15 seconds per turn, 4-5 minutes total OR 10 turns per player)
+- Movement system (4 moves per game, left/right only, movement scoring)
+- Physics calculations (Matter.js, gravity varies by arena, no wind)
+- Action processing (aim, fire, move)
+- Scoring system (accuracy, back-to-back hits, repositioning saves)
+- Health system (different HP per hero type, balanced HP when matched)
+- Win condition detection (HP = 0 = instant loss, or player with more HP at match end)
+- Draw condition detection (same HP AND same score = draw)
+- Weapon synergy system (dynamic system, e.g., gasoline + torch)
+- Match result processing
+- Configuration file support (weapons, penalties, rank tiers, scoring formulas)
+- Disconnection handling (1 minute rejoin window, configurable penalties)
 
 ## Status
-🚧 Just set up - ready for implementation
 
+🚧 **Ready for Implementation**

--- a/backend-services/leaderboard-service/README.md
+++ b/backend-services/leaderboard-service/README.md
@@ -1,20 +1,29 @@
 # Leaderboard Service
 
-Spring Boot service for rankings and leaderboards.
+Spring Boot service for rankings and leaderboards with filtering capabilities.
+
+## Description
+
+The Leaderboard Service generates and maintains global leaderboards with advanced filtering options including region, hero type, winning percentage, and weapon usage.
+
+## Technology Stack
+
+- **Framework:** Spring Boot 3.x
+- **Language:** Java 17
+- **Database:** MongoDB (Leaderboard collection)
 
 ## Port
-8083
 
-## Tech Stack
-- Spring Boot 3.x
-- Java 17
-- MongoDB
+**8083**
 
-## What It Does
+## Responsibilities
+
 - Top players ranking
-- Leaderboard with filtering (region, hero type, win percentage, weapons)
-- Player rankings display
+- Leaderboard generation with filtering (region, hero type, winning percentage, weapons)
+- Rank tier calculation (score ranges determine rank tiers like Valorant)
+- Ranking algorithms (global score determines rankings, players with similar ranks can be in top 5)
+- Statistics aggregation
 
 ## Status
-🚧 Just set up - ready for implementation
 
+🚧 **Ready for Implementation**

--- a/backend-services/matchmaking-service/README.md
+++ b/backend-services/matchmaking-service/README.md
@@ -1,23 +1,35 @@
 # Matchmaking Service
 
-Node.js service for handling matchmaking, hero selection, and player queues.
+Node.js service for hero selection, matchmaking, and pre-match setup (arena/weapon selection).
+
+## Description
+
+The Matchmaking Service handles the complete matchmaking flow including hero selection, skill-based player matching, arena voting, and weapon selection before starting a game.
+
+## Technology Stack
+
+- **Runtime:** Node.js 18+
+- **Framework:** Express
+- **Real-time:** Socket.io (WebSocket)
+- **Cache:** Redis (Matchmaking queue, Lobby storage, Configuration cache)
 
 ## Port
-3002
 
-## Tech Stack
-- Node.js
-- Express
-- Socket.io (WebSocket)
-- Redis (Queue and Lobby storage)
+**3002**
 
-## What It Does
-- Hero selection management
+## Responsibilities
+
+- Hero selection management (multiple hero selection, hero matching, hero assignment)
 - Player queue management
-- Matchmaking algorithm (skill-based)
-- Arena/weapon selection
-- Finding opponents for players
+- Global score/rank-based matchmaking algorithm
+- Queue expansion (after 5 minutes, widen XP/score/rank range)
+- Arena selection management (voting/elimination system)
+- Weapon selection management (alternating selection, 30-second timer)
+- Lobby creation and management
+- Match acceptance handling
+- Estimated wait time calculation
+- Reconnection handling
 
 ## Status
-🚧 Just set up - ready for implementation
 
+🚧 **Ready for Implementation**

--- a/backend-services/profile-service/README.md
+++ b/backend-services/profile-service/README.md
@@ -1,23 +1,31 @@
 # Profile Service
 
-Spring Boot service for managing user profiles, scores, and statistics.
+Spring Boot service for managing user profiles, scores, and player statistics.
+
+## Description
+
+The Profile Service manages player profiles, tracks global scores (infinite with no level cap), calculates rank tiers (Valorant-style), and maintains player statistics.
+
+## Technology Stack
+
+- **Framework:** Spring Boot 3.x
+- **Language:** Java 17
+- **Database:** MongoDB (Profiles collection)
+- **Cache:** Redis (optional caching)
 
 ## Port
-8082
 
-## Tech Stack
-- Spring Boot 3.x
-- Java 17
-- MongoDB
-- Redis (caching)
+**8082**
 
-## What It Does
+## Responsibilities
+
 - User profile management
-- Global score tracking (infinite, no level cap)
-- Rank tier calculation (Valorant-style)
-- Win/loss statistics
-- Profile updates
+- Global score tracking and update (not per-hero, score can be infinite, no level cap)
+- Rank tier calculation (like Valorant, based on score ranges)
+- Player statistics (wins, losses, matches played)
+- Avatar management
+- Rank change calculation (based on match score)
 
 ## Status
-🚧 Just set up - ready for implementation
 
+🚧 **Ready for Implementation**

--- a/frontend-service/README.md
+++ b/frontend-service/README.md
@@ -1,59 +1,65 @@
-# FrontendService
+# Frontend Service
 
-This project was generated using [Angular CLI](https://github.com/angular/angular-cli) version 20.3.10.
+Angular application for Battle Arena - the client-facing web application.
 
-## Development server
+## Description
 
-To start a local development server, run:
+The Frontend Service is the Angular-based web application that provides the user interface for Battle Arena, including authentication, dashboard, matchmaking UI, and the game arena with Phaser 3 integration.
+
+## Technology Stack
+
+- **Framework:** Angular 17+
+- **Language:** TypeScript
+- **Styling:** TailwindCSS
+- **Game Framework:** Phaser 3
+- **Build Tool:** Angular CLI
+
+## Port
+
+**4200** (development)
+
+## Responsibilities
+
+- User authentication UI (login, registration, Google OAuth)
+- Dashboard and profile management
+- Hero selection interface
+- Matchmaking UI and queue display
+- Arena and weapon selection UI
+- Game arena interface with Phaser 3 integration
+- Real-time game rendering and interactions
+- Leaderboard display with filtering
+- Responsive design for multiple screen sizes
+
+## Development
+
+This project was generated with [Angular CLI](https://github.com/angular/angular-cli).
+
+### Development Server
 
 ```bash
 ng serve
 ```
 
-Once the server is running, open your browser and navigate to `http://localhost:4200/`. The application will automatically reload whenever you modify any of the source files.
+Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.
 
-## Code scaffolding
-
-Angular CLI includes powerful code scaffolding tools. To generate a new component, run:
-
-```bash
-ng generate component component-name
-```
-
-For a complete list of available schematics (such as `components`, `directives`, or `pipes`), run:
-
-```bash
-ng generate --help
-```
-
-## Building
-
-To build the project run:
+### Build
 
 ```bash
 ng build
 ```
 
-This will compile your project and store the build artifacts in the `dist/` directory. By default, the production build optimizes your application for performance and speed.
+The build artifacts will be stored in the `dist/` directory.
 
-## Running unit tests
-
-To execute unit tests with the [Karma](https://karma-runner.github.io) test runner, use the following command:
+### Running Tests
 
 ```bash
+# Unit tests
 ng test
-```
 
-## Running end-to-end tests
-
-For end-to-end (e2e) testing, run:
-
-```bash
+# End-to-end tests
 ng e2e
 ```
 
-Angular CLI does not come with an end-to-end testing framework by default. You can choose one that suits your needs.
+## Status
 
-## Additional Resources
-
-For more information on using the Angular CLI, including detailed command references, visit the [Angular CLI Overview and Command Reference](https://angular.dev/tools/cli) page.
+🚧 **Ready for Implementation**


### PR DESCRIPTION
Related to #100 & #99 

TASK-1-1-8: Create service-specific README files
- Update auth-service README with description, tech stack, port, responsibilities
- Update profile-service README with description, tech stack, port, responsibilities
- Update leaderboard-service README with description, tech stack, port, responsibilities
- Update matchmaking-service README with description, tech stack, port, responsibilities
- Update game-engine README with description, tech stack, port, responsibilities
- Update frontend-service README with Angular-specific details and development instructions

TASK-1-1-9: Enhance root README.md
- Add status badges (status, license, Java, Node, Angular)
- Add comprehensive architecture overview with service table (ports, tech, descriptions)
- Add detailed service list with ports:
  * Auth Service (Spring Boot, 8081)
  * Profile Service (Spring Boot, 8082)
  * Leaderboard Service (Spring Boot, 8083)
  * Matchmaking Service (Node.js, 3002)
  * Game Engine Service (Node.js, 5002)
  * Frontend Service (Angular, 4200)
- Add data stores and API Gateway sections
- Enhance prerequisites section
- Add service access URLs in getting started
- Expand documentation section with categorized links
- Add Development section with workflow and testing instructions
- All services marked as 'Ready for Implementation'

Closes #100
Closes #99 