### PR TITLE
fix: Use full commit SHA for OWASP Dependency Check action (security best practice)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -41,7 +41,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y jq
       
       - name: Run OWASP Dependency Check
-        uses: dependency-check/Dependency-Check_Action@main
+        uses: dependency-check/Dependency-Check_Action@2ba636726705b0f74f126ebeaacaf2ad4600b967
         id: depcheck
         with:
           project: '${{ matrix.service }}'


### PR DESCRIPTION
- Replace @main with full commit SHA: 2ba636726705b0f74f126ebeaacaf2ad4600b967
- Improves security by pinning to exact version
- Prevents supply chain attacks from branch manipulation
- Consistent with SonarCloud action security practice

Related to: #87 