### PR TITLE
fix: The package-lock.json files are gitignored, so they don't exist in the checked-out repository, causing cache path resolution errors.

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -94,17 +94,33 @@ jobs:
         with:
           fetch-depth: 0
       
+      - name: Check if package-lock.json exists
+        id: check_lockfile
+        run: |
+          if [ -f package-lock.json ]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+        continue-on-error: true
+      
       - name: Set up Node.js 18
         uses: actions/setup-node@v4
         with:
           node-version: '18'
-          cache: 'npm'
-          cache-dependency-path: backend-services/${{ matrix.service }}/package-lock.json
+          cache: ${{ steps.check_lockfile.outputs.exists == 'true' && 'npm' || '' }}
+          cache-dependency-path: ${{ steps.check_lockfile.outputs.exists == 'true' && format('backend-services/{0}/package-lock.json', matrix.service) || '' }}
         continue-on-error: true
-        if: always()
       
       - name: Install dependencies
-        run: npm ci
+        run: |
+          if [ -f package-lock.json ]; then
+            npm ci
+          else
+            echo "package-lock.json not found in repository (likely gitignored), using npm install"
+            npm install
+          fi
+        continue-on-error: false
       
       - name: Run tests with coverage
         run: |


### PR DESCRIPTION

How it works now:
1. Check if package-lock.json exists → Yes/No
2. If Yes → Enable cache, use npm ci
3. If No → Skip cache, use npm install
Related to #87