### PR TITLE
fix: Remove npm cache for Node.js backend services

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -94,32 +94,16 @@ jobs:
         with:
           fetch-depth: 0
       
-      - name: Check if package-lock.json exists
-        id: check_lockfile
-        run: |
-          if [ -f package-lock.json ]; then
-            echo "exists=true" >> $GITHUB_OUTPUT
-          else
-            echo "exists=false" >> $GITHUB_OUTPUT
-          fi
-        continue-on-error: true
-      
       - name: Set up Node.js 18
         uses: actions/setup-node@v4
         with:
           node-version: '18'
-          cache: ${{ steps.check_lockfile.outputs.exists == 'true' && 'npm' || '' }}
-          cache-dependency-path: ${{ steps.check_lockfile.outputs.exists == 'true' && format('backend-services/{0}/package-lock.json', matrix.service) || '' }}
-        continue-on-error: true
+          # Cache disabled - package-lock.json is gitignored for these services
       
       - name: Install dependencies
         run: |
-          if [ -f package-lock.json ]; then
-            npm ci
-          else
-            echo "package-lock.json not found in repository (likely gitignored), using npm install"
-            npm install
-          fi
+          echo "Installing dependencies (package-lock.json is gitignored, using npm install)"
+          npm install
         continue-on-error: false
       
       - name: Run tests with coverage


### PR DESCRIPTION
- package-lock.json files are gitignored for matchmaking-service and game-engine
- Removing cache entirely to avoid cache path resolution errors
- Frontend still uses cache (package-lock.json is committed)
- Simplifies workflow and fixes cache errors

Related to #87